### PR TITLE
Update Report schema and AI Prompt for scheduled follow-ups

### DIFF
--- a/src/actions/report.ts
+++ b/src/actions/report.ts
@@ -21,9 +21,9 @@ Your response should follow this exact JSON schema:
   "diagnosis": "Life-saving diagnosis methods based on the readings",
   "recommendations": "Try to give Accurate Treatment recommendations and follow-up suggestions everytime",
   "urgencyLevel": "Low/Medium/High - Include these parameters according to your findings and alert the patient accordingly",
-  "additionalNotes": "Any other relevant medical observations or concerns you want to give from your experience and It should also give the patient a safe/proper diet and yoga/exercise plan for speedy recovery in a short and concise manner and in a plain text",
-  "tests": "Include information about all the tests that has to be done in plain english test with schedule like hourly, daily, weekly, monthly, quaterly, yearly according to your intelligence in this section",
-  followupSchedule": "It should include a single cron job schedule only for patients as per their situations like daily, hourly, weekly, monthly,quaterly,half yearly,yearly in cron job format "
+  "additionalNotes": "Any other relevant medical observations or concerns you want to give from your experience. It should also give the patient a safe/proper diet and yoga/exercise plan for speedy recovery in a short and concise manner in a plain text",
+  "tests": "Includes information about all the tests that are needed to be done in plain english sentence. Keep this very concise.",
+  "followupSchedule": "A single cron job schedule for followup visits to doctor without any additional text as per their condition or leave empty string if not required. Do not use nonstandard cron formats."
 
 }
 
@@ -36,8 +36,7 @@ Your report should:
 - Format all values with appropriate units
 - Prioritize patient's health and safety in all recommendations being economical at the same time
 - Also, mention the ranges if the readings come severe for any reading
-- It should include cron job scheduling for patients as per their situations like daily, hourly, weekly, monthly,quaterly,half yearly,yearly and be careful in this as if a patient is not given a proper treatment on time then it may cause a lot of harm to them even DEATH also
-- And be careful job scheduling as if a patient is not given a proper treatment on time then it may cause a lot of harm to them even DEATH also
+- It should include cron job schedule for patient followup visit as per their condition or empty string if no followup is required. Be careful in this as if a patient is not given a proper treatment on time then it may cause a lot of harm to them even DEATH also.
 
 Also, NEVER use markdown syntax. Respond in plaintext only.
 
@@ -115,8 +114,8 @@ export async function generateReport(
             recommendations: { type: Type.STRING, nullable: false },
             urgencyLevel: { type: Type.STRING, nullable: false },
             additionalNotes: { type: Type.STRING, nullable: false },
-            tests: { type: Type.STRING, nullable: false},
-            followupSchedule: {type: Type.STRING , nullable: false}
+            tests: { type: Type.STRING, nullable: false },
+            followupSchedule: { type: Type.STRING, nullable: false }
           },
           required: [
             "summary",
@@ -179,7 +178,7 @@ export async function getReportById(reportId: string): Promise<Report | null> {
     return report
   } catch (error) {
     console.log(error)
-    throw new Error("Failed to get report")
+    throw new Error("Failed to get report", error)
   }
 }
 

--- a/src/actions/report.ts
+++ b/src/actions/report.ts
@@ -21,7 +21,10 @@ Your response should follow this exact JSON schema:
   "diagnosis": "Life-saving diagnosis methods based on the readings",
   "recommendations": "Try to give Accurate Treatment recommendations and follow-up suggestions everytime",
   "urgencyLevel": "Low/Medium/High - Include these parameters according to your findings and alert the patient accordingly",
-  "additionalNotes": "Any other relevant medical observations or concerns you want to give from your experience"
+  "additionalNotes": "Any other relevant medical observations or concerns you want to give from your experience and It should also give the patient a safe/proper diet and yoga/exercise plan for speedy recovery in a short and concise manner and in a plain text",
+  "tests": "Include information about all the tests that has to be done in plain english test with schedule like hourly, daily, weekly, monthly, quaterly, yearly according to your intelligence in this section",
+  followupSchedule": "It should include a single cron job schedule only for patients as per their situations like daily, hourly, weekly, monthly,quaterly,half yearly,yearly in cron job format "
+
 }
 
 Your report should:
@@ -33,6 +36,8 @@ Your report should:
 - Format all values with appropriate units
 - Prioritize patient's health and safety in all recommendations being economical at the same time
 - Also, mention the ranges if the readings come severe for any reading
+- It should include cron job scheduling for patients as per their situations like daily, hourly, weekly, monthly,quaterly,half yearly,yearly and be careful in this as if a patient is not given a proper treatment on time then it may cause a lot of harm to them even DEATH also
+- And be careful job scheduling as if a patient is not given a proper treatment on time then it may cause a lot of harm to them even DEATH also
 
 Also, NEVER use markdown syntax. Respond in plaintext only.
 
@@ -109,7 +114,9 @@ export async function generateReport(
             diagnosis: { type: Type.STRING, nullable: false },
             recommendations: { type: Type.STRING, nullable: false },
             urgencyLevel: { type: Type.STRING, nullable: false },
-            additionalNotes: { type: Type.STRING, nullable: false }
+            additionalNotes: { type: Type.STRING, nullable: false },
+            tests: { type: Type.STRING, nullable: false},
+            followupSchedule: {type: Type.STRING , nullable: false}
           },
           required: [
             "summary",
@@ -117,7 +124,9 @@ export async function generateReport(
             "diagnosis",
             "recommendations",
             "urgencyLevel",
-            "additionalNotes"
+            "additionalNotes",
+            "tests",
+            "followupSchedule"
           ]
         }
       }

--- a/src/db/schema.prisma
+++ b/src/db/schema.prisma
@@ -90,9 +90,9 @@ model Report {
   recommendations  String       @db.Text
   urgencyLevel     UrgencyLevel
   additionalNotes  String       @db.Text
-  jobId            Int?
   tests            String
   followupSchedule String
+  jobId            Int?
   createdAt        DateTime     @default(now())
   updatedAt        DateTime     @default(now()) @updatedAt
 }

--- a/src/db/schema.prisma
+++ b/src/db/schema.prisma
@@ -92,4 +92,6 @@ model Report {
   additionalNotes  String       @db.Text
   createdAt        DateTime     @default(now())
   updatedAt        DateTime     @default(now()) @updatedAt
+  jobId            Int?
+  followupSchedule String
 }

--- a/src/db/schema.prisma
+++ b/src/db/schema.prisma
@@ -90,8 +90,9 @@ model Report {
   recommendations  String       @db.Text
   urgencyLevel     UrgencyLevel
   additionalNotes  String       @db.Text
+  jobId            Int?
+  tests            String
+  followupSchedule String
   createdAt        DateTime     @default(now())
   updatedAt        DateTime     @default(now()) @updatedAt
-  jobId            Int?
-  followupSchedule String
 }


### PR DESCRIPTION
Updated the schema to include `jobId` and `followupSchedule`
Also updated the AI prompt to ask it to suggest a follow-up schedule in cron job format.

Closes #4 